### PR TITLE
Correct checkout actions in README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: CFC-Servers/gmod-upload@master
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          path: project
+      - name: Upload to Workshop
+        uses: CFC-Servers/gmod-upload@master
         with:
           id: 2466875474
           changelog: "Deployment via Github to latest changes"
@@ -44,8 +48,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: CFC-Servers/gmod-upload@master
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          path: project
+      - name: Upload to Workshop
+        uses: CFC-Servers/gmod-upload@master
         with:
           id: 2466875474
           changelog: "Deployment via Github to latest changes"
@@ -68,8 +76,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: CFC-Servers/gmod-upload@master
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          path: project
+      - name: Upload to Workshop
+        uses: CFC-Servers/gmod-upload@master
         with:
           id: 2466875474
           changelog: "Deployment via Github to latest changes"


### PR DESCRIPTION
The checkout actions in the examples don't use the path that the upload action expects them to, which causes the checkout to run again later and prevents any file changes from being made in between the checkout and upload (for example, automatic version updates). Maybe this can help save some other poor soul from the confusion that this problem brought me while setting up an action based on these examples?

I also added names to the steps to more clearly separate them when viewing the action logs because why not